### PR TITLE
ci: pin GitHub Actions to full commit SHA

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,21 +2,21 @@ name: 'Setup'
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v4.0.0
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
     - name: Set up Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         cache: 'pnpm'
         node-version: ${{ matrix.node-version }}
     - name: Cache pnpm
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: ~/.pnpm-store
         key: ${{ matrix.node-version }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: ${{ matrix.node-version }}-pnpm-
     - name: Cache node_modules
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       id: cache-node-modules
       with:
         path: node_modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup
         uses: ./.github/actions/setup
 
@@ -22,7 +22,7 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint & format code
@@ -35,11 +35,11 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
       - name: Test
         run: pnpm test:ci
         env:
@@ -56,7 +56,7 @@ jobs:
       matrix:
         node-version: [18]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,13 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Publish to NPM
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset:release
         env:


### PR DESCRIPTION
SHA-pin all actions. Mutable tags can be force-pushed if an action repo is compromised, and evaporate if it is disabled (cf. Azure/functions-action, Jun 5 Miasma). Stopgap ahead of Renovate digest maintenance. Ref: Miasma scan 2026-06-09.